### PR TITLE
Add NGiNX reverse proxy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,9 @@ RUN curl -O http://downloads.mirthcorp.com/connect/3.1.1.7461.b23/mirthconnect-3
 RUN chmod +x mirthconnect-3.1.1.7461.b23-unix.sh mirthconnect-install-wrapper.sh mirthconnect-wrapper.sh
 RUN ./mirthconnect-install-wrapper.sh
 
-EXPOSE 80 9661
+RUN apt-get -y install nginx
+ADD templates/etc /etc
+
+EXPOSE 3000 9661
 
 CMD ./mirthconnect-wrapper.sh

--- a/templates/etc/nginx/nginx.conf
+++ b/templates/etc/nginx/nginx.conf
@@ -1,0 +1,69 @@
+user www-data;
+worker_processes 4;
+pid /run/nginx.pid;
+
+events {
+  worker_connections 768;
+}
+
+http {
+  sendfile on;
+  tcp_nopush on;
+  tcp_nodelay on;
+  keepalive_timeout 65;
+  types_hash_max_size 2048;
+  client_max_body_size 0;
+
+  # http://stackoverflow.com/a/3710649
+  proxy_buffers 8 16k;
+  proxy_buffer_size 32k;
+
+  include /etc/nginx/mime.types;
+  default_type application/octet-stream;
+
+  access_log /dev/stdout;
+  error_log /dev/stdout;
+
+  gzip on;
+  gzip_disable "msie6";
+
+  # http://serverfault.com/a/637849
+  # Enable PFS for most browsers, and provide SSLv3 while mitigating POODLE
+  ssl_ciphers EECDH+ECDSA+AESGCM:EECDH+aRSA+AESGCM:EECDH+ECDSA+SHA384:EECDH+ECDSA+SHA256:EECDH+aRSA+SHA384:EECDH+aRSA+SHA256:EECDH+aRSA+RC4:EECDH:EDH+aRSA:RC4:!aNULL:!eNULL:!LOW:!3DES:!MD5:!EXP:!PSK:!SRP:!DSS:!CAMELLIA;
+  ssl_protocols SSLv3 TLSv1 TLSv1.1 TLSv1.2;
+  ssl_prefer_server_ciphers on;
+
+  # X-Forwarded-Proto -intelligent proxy for Mirth Connect
+  upstream mirth_http {
+    server localhost:80;
+  }
+
+  upstream mirth_https {
+    server localhost:443;
+  }
+
+  server {
+    listen 3000;
+    keepalive_timeout 5;
+
+    location / {
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header Host $http_host;
+      proxy_redirect off;
+
+      if ($http_x_forwarded_proto != 'https') {
+        proxy_pass http://mirth_http;
+      }
+      if ($http_x_forwarded_proto = 'https') {
+        proxy_pass https://mirth_https;
+      }
+
+      proxy_http_version 1.1;
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection "upgrade";
+
+      break;
+    }
+
+  }
+}

--- a/templates/mirthconnect/mirthconnect-wrapper.sh
+++ b/templates/mirthconnect/mirthconnect-wrapper.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# Start NGiNX reverse proxy
+/usr/sbin/nginx
+
+# Start Mirth Connect
 ./mcservice start
 while ! echo exit | nc localhost 443; do sleep 0.1; done
 java -jar mirth-cli-launcher.jar -a https://localhost:443 -u admin -p admin -v 0.0.0 -s mirthconnect-cli.txt


### PR DESCRIPTION
This works around Mirth Connect's disrespect for X-Forwarded-Proto headers.

@jamesdempsey: This should resolve the issue of deployability on Aptible. To test locally (with these changes):

```
cd docker-mirthconnect
docker build -t jamesdempsey/mirthconnect .
docker run -i -t -d -p 3000:3000 -p 9661:9661 jamesdempsey/mirthconnect
docker run -i -t -p 443:443 -p 80:80 -e UPSTREAM_SERVERS=$(boot2docker ip 2>/dev/null):3000 quay.io/aptible/nginx
```

Now visiting `https://$DOCKER_IP` works as expected.
